### PR TITLE
added mDNS so it could be found via http://kame.local

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,8 @@ platform = espressif32@3.5.0   ;Version needed due to error <undefined reference
 board = wemos_d1_mini32
 framework = arduino
 lib_deps = 
-	madhephaestus/ESP32Servo
+	arduino-mdns
+    madhephaestus/ESP32Servo
     ;madhephaestus/ESP32Servo@^1.1.1        ;the version was suggested as part of an arduino import process... so I keep it noted just in case
 	me-no-dev/ESP Async WebServer
     ;me-no-dev/ESP Async WebServer@^1.2.3   ;the version was suggested as part of an arduino import process... so I keep it noted just in case

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,9 @@
 // ServoArm 21, 17, 16
 
 #include <Arduino.h>
+#include <ESPmDNS.h>
+
+
 //#include <WiFi.h>
 //#include <WiFiMulti_Generic.h>
 //#include <SoftwareSerial.h>
@@ -159,6 +162,12 @@ void setup() {
   
   pinMode(output, OUTPUT);
   digitalWrite(output, LOW);
+
+   // Start mDNS
+  MDNS.begin("kame");
+  MDNS.addService("http", "tcp", 80);
+  
+
   
   // Send web page to client
   server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){


### PR DESCRIPTION
caveat:
 - not working for all client devices (e.g. linux and android)
 - for android works via additional app, e.g. BonjourBrowser is nice/ simple
 - linux needs additional setup (on manjaro avahi-services) which I couldnt get to work
 - did not test on windows but www says it should work :/